### PR TITLE
Update controllers to use AdapterInterface.

### DIFF
--- a/src/Controller/ClientController.php
+++ b/src/Controller/ClientController.php
@@ -9,7 +9,6 @@ use Zend\Console\ColorInterface as Color;
 use Zend\Console\Prompt;
 use RuntimeException;
 use Doctrine\Common\Collections\ArrayCollection;
-use Zend\Console\Adapter\Posix;
 use Doctrine\ORM\EntityManager;
 
 class ClientController extends AbstractActionController
@@ -18,7 +17,7 @@ class ClientController extends AbstractActionController
     protected $console;
     protected $objectManager;
 
-    public function __construct(Array $config, Posix $console, EntityManager $objectManager)
+    public function __construct(Array $config, Console $console, EntityManager $objectManager)
     {
         $this->config = $config;
         $this->console = $console;
@@ -101,10 +100,10 @@ class ClientController extends AbstractActionController
                 continue;
             }
 
-            $clientEntity->setSecret(   
+            $clientEntity->setSecret(
                 password_hash(
-                    $secret, 
-                    PASSWORD_BCRYPT, 
+                    $secret,
+                    PASSWORD_BCRYPT,
                     ['cost' => $config['bcrypt_cost']]
                 )
             );
@@ -279,10 +278,10 @@ class ClientController extends AbstractActionController
                 continue;
             }
 
-            $clientEntity->setSecret(   
+            $clientEntity->setSecret(
                 password_hash(
-                    $secret, 
-                    PASSWORD_BCRYPT, 
+                    $secret,
+                    PASSWORD_BCRYPT,
                     ['cost' => $config['bcrypt_cost']]
                 )
             );

--- a/src/Controller/ClientController.php
+++ b/src/Controller/ClientController.php
@@ -90,9 +90,10 @@ class ClientController extends AbstractActionController
         $secret = '';
         $secretVerify = false;
         while ($secret !== $secretVerify) {
-            $secretPrompt = new Prompt\Password("Secret: ");
+            // there is a problem with Prompt\Password in Windows consoles...
+            $secretPrompt = new Prompt\Line("Secret: ");
             $secret = $secretPrompt->show();
-            $secretPrompt = new Prompt\Password("Verify Secret: ");
+            $secretPrompt = new Prompt\Line("Verify Secret: ");
             $secretVerify = $secretPrompt->show();
 
             if ($secret !== $secretVerify) {

--- a/src/Controller/ClientController.php
+++ b/src/Controller/ClientController.php
@@ -269,9 +269,9 @@ class ClientController extends AbstractActionController
         $secret = '';
         $secretVerify = false;
         while ($secret !== $secretVerify) {
-            $secretPrompt = new Prompt\Password("Secret: ");
+            $secretPrompt = new Prompt\Line("Secret: ");
             $secret = $secretPrompt->show();
-            $secretPrompt = new Prompt\Password("Verify Secret: ");
+            $secretPrompt = new Prompt\Line("Verify Secret: ");
             $secretVerify = $secretPrompt->show();
 
             if ($secret !== $secretVerify) {

--- a/src/Controller/JwtController.php
+++ b/src/Controller/JwtController.php
@@ -9,7 +9,6 @@ use Zend\Console\ColorInterface as Color;
 use Zend\Console\Prompt;
 use RuntimeException;
 use ZF\OAuth2\Doctrine\Entity;
-use Zend\Console\Adapter\Posix;
 use Doctrine\ORM\EntityManager;
 
 class JwtController extends AbstractActionController
@@ -18,7 +17,7 @@ class JwtController extends AbstractActionController
     protected $console;
     protected $objectManager;
 
-    public function __construct(Array $config, Posix $console, EntityManager $objectManager)
+    public function __construct(Array $config, Console $console, EntityManager $objectManager)
     {
         $this->config = $config;
         $this->console = $console;

--- a/src/Controller/PublicKeyController.php
+++ b/src/Controller/PublicKeyController.php
@@ -9,7 +9,6 @@ use Zend\Console\ColorInterface as Color;
 use Zend\Console\Prompt;
 use RuntimeException;
 use ZF\OAuth2\Doctrine\Entity;
-use Zend\Console\Adapter\Posix;
 use Doctrine\ORM\EntityManager;
 
 class PublicKeyController extends AbstractActionController
@@ -18,7 +17,7 @@ class PublicKeyController extends AbstractActionController
     protected $console;
     protected $objectManager;
 
-    public function __construct(Array $config, Posix $console, EntityManager $objectManager)
+    public function __construct(Array $config, Console $console, EntityManager $objectManager)
     {
         $this->config = $config;
         $this->console = $console;

--- a/src/Controller/ScopeController.php
+++ b/src/Controller/ScopeController.php
@@ -8,7 +8,6 @@ use Zend\Console\Adapter\AdapterInterface as Console;
 use Zend\Console\ColorInterface as Color;
 use Zend\Console\Prompt;
 use RuntimeException;
-use Zend\Console\Adapter\Posix;
 use Doctrine\ORM\EntityManager;
 
 class ScopeController extends AbstractActionController
@@ -17,7 +16,7 @@ class ScopeController extends AbstractActionController
     protected $console;
     protected $objectManager;
 
-    public function __construct(Array $config, Posix $console, EntityManager $objectManager)
+    public function __construct(Array $config, Console $console, EntityManager $objectManager)
     {
         $this->config = $config;
         $this->console = $console;


### PR DESCRIPTION
This allows for the use of this module on different OS platforms, eg: Windows.
Replaces the Posix Adapter with the Console\AdapterInterface.

I have also added a commit that changes the Prompt\Password in the ClientController.
There is a bug in zend-console where the Password class gets jammed into an infinite loop.
